### PR TITLE
Add domain-loss visualization utility

### DIFF
--- a/example/p_laplacian.py
+++ b/example/p_laplacian.py
@@ -129,7 +129,6 @@ save_surface_path = os.path.join(save_dir, "prediction_surface.png")
 pinns.prediction_surface(
     model=model,
     domain=domain,
-    mask_fn=domain.visualization_mask,
     save_path=save_surface_path,
     cmap="hsv",
     dpi=450,
@@ -142,7 +141,6 @@ pinns.domain_loss_heatmap(
     model=model,
     problem=problem,
     domain=domain,
-    mask_fn=domain.visualization_mask,
     save_path=save_domain_loss_path,
     cmap="inferno",
     dpi=450,

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -35,5 +35,7 @@ __all__ = [
     # Utils
     'training_data_plot',
     'loss_curve',
-    'prediction_and_error'
+    'prediction_and_error',
+    'prediction_surface',
+    'domain_loss_heatmap',
 ]


### PR DESCRIPTION
## Summary
- derive mesh grid from domain boundary and collocation points
- split prediction plots into `prediction_surface` and `domain_loss_heatmap`
- update p-Laplacian example to use new visualization helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbee1bb9fc8324a6e7792a9ecb2b77

## Summary by Sourcery

Introduce dedicated visualization utilities for PINN experiments, including mesh grid preparation, 3D prediction surfaces, and domain-loss heatmaps, refactor existing loss plotting for greater flexibility, and update the p-Laplacian example to leverage the new helpers

New Features:
- Generate mesh grids from domain boundaries and collocation points via a helper function
- Add prediction_surface utility to render model predictions as 3D surfaces
- Add domain_loss_heatmap utility to visualize squared PDE residuals as 2D heatmaps

Enhancements:
- Refactor loss_curve to accept an existing axes object and return the figure and axes
- Export new visualization functions in the package __init__.py

Chores:
- Update the p-Laplacian example script to use the new visualization helpers in place of custom plotting code