### PR TITLE
Add checkpointing and Net2Net weight initialization

### DIFF
--- a/example/p_laplacian.py
+++ b/example/p_laplacian.py
@@ -87,34 +87,32 @@ problem = pinns.PDEProblem(
 )
 
 # 3. Create PINN (network + loss only)
+state_dict_path = r"saved_model_and_graph\20250907-170048\model_p3.pt"
 model = pinns.NeuralNet(
     input_dim=2,
-    hidden_dim=50,
+    hidden_dim=80,
     output_dim=1,
     num_hidden_layers=4,
     activation="tanh",
+    state_dict_path=state_dict_path,
 )
 
 # 4. Create trainer with strategy
+save_model_path = os.path.join(save_dir, "model.pt")
 trainer = pinns.Trainer(
     model=model,
     problem=problem,
     domain=domain,
     optimizer_config={"type": "adam", "lr": 1e-2},
     strategy="standard",  # or pinns.AdaptiveSamplingStrategy()
+    save_path=save_model_path,
+    checkpoint_interval=100,
 )
+
 # 5. Train
-results = trainer.train(epochs=2500, loss_threshold=1e-4)
+results = trainer.train(epochs=2000, loss_threshold=1e-4)
 
-# 6. Visualization and saving
-
-# Save the model
-# optimizer_type = getattr(trainer.optimizer, "adam")
-optimizer_type = "adam"
-save_model_path = os.path.join(save_dir, f"{optimizer_type}.pt")
-torch.save(model.state_dict(), save_model_path)
-print(f"Model saved to {save_model_path}")
-
+# 6. Visualization
 # Loss curve
 save_loss_graph = os.path.join(save_dir, "loss_function_graph.png")
 pinns.loss_curve(

--- a/src/core/neural_net.py
+++ b/src/core/neural_net.py
@@ -1,10 +1,11 @@
 """Neural network architectures for PINNs."""
 
+from typing import Optional
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from typing import Optional
 
 from src.utils.net2net import widen_linear
 
@@ -66,7 +67,7 @@ class NeuralNet(nn.Module):
         self.to(device=device, dtype=dtype)
 
         if state_dict_path is not None:
-            self._initialize_from_checkpoint(state_dict_path)
+            self.__initialize_from_checkpoint(state_dict_path)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Compute network outputs for the given input coordinates."""
@@ -75,37 +76,73 @@ class NeuralNet(nn.Module):
             x = self.activation(hidden_layer(x))
         return self.output_layer(x)
 
-    # ------------------------------------------------------------------
-    def _initialize_from_checkpoint(self, path: str) -> None:
-        """Load weights from a checkpoint, widening layers if needed."""
+    def __initialize_from_checkpoint(self, path: str) -> None:
+        """
+        Load weights from a checkpoint and perform function-preserving *widening* per layer if needed.
+
+        Rules:
+          - Load matching-shape tensors first.
+          - If a layer's new width is smaller than the checkpoint width, raise:
+                function-preserving shrinking is not generally possible.
+          - If widths match, do nothing (already loaded).
+          - If the new width is larger, copy the leading block then widen by duplication/splitting.
+        """
         checkpoint = torch.load(path, map_location=self.device)
-        state_dict = checkpoint.get("model_state", checkpoint)
+        ckpt_sd = checkpoint.get("model_state", checkpoint)
+        print(f"Initializing network from checkpoint: {path}")
 
-        # Load matching parameters
-        self.load_state_dict(state_dict, strict=False)
+        # 1) Load only compatible tensors (avoids size-mismatch).
+        current_sd = self.state_dict()
+        compatible_sd = {k: v for k, v in ckpt_sd.items()
+                         if k in current_sd and current_sd[k].shape == v.shape}
+        self.load_state_dict(compatible_sd, strict=False)
 
-        layers = [self.input_layer] + list(self.hidden_layers) + [self.output_layer]
-        names = ["input_layer"] + [f"hidden_layers.{i}" for i in range(len(self.hidden_layers))] + ["output_layer"]
+        # 2) Walk adjacent pairs and handle width changes
+        layers = [self.input_layer] + \
+            list(self.hidden_layers) + [self.output_layer]
+        names = ["input_layer"] + [f"hidden_layers.{i}" for i in range(
+            len(self.hidden_layers))] + ["output_layer"]
 
-        for i in range(len(layers) - 1):
-            name, next_name = names[i], names[i + 1]
-            w_old = state_dict.get(f"{name}.weight")
-            if w_old is None:
-                continue
-            h_old = w_old.shape[0]
-            h_new = layers[i].weight.shape[0]
-            add_k = h_new - h_old
-            if add_k <= 0:
-                continue
+        with torch.no_grad():
+            for i in range(len(layers) - 1):
+                name, next_name = names[i], names[i + 1]
 
-            b_old = state_dict.get(f"{name}.bias")
-            layers[i].weight.data[:h_old, :w_old.shape[1]] = w_old
-            if b_old is not None:
-                layers[i].bias.data[:h_old] = b_old
+                W_old = ckpt_sd.get(f"{name}.weight")
+                b_old = ckpt_sd.get(f"{name}.bias")
+                Wnext_old = ckpt_sd.get(f"{next_name}.weight")
+                bnext_old = ckpt_sd.get(f"{next_name}.bias")
 
-            wnext_old = state_dict.get(f"{next_name}.weight")
-            if wnext_old is None:
-                continue
-            layers[i + 1].weight.data[:, :wnext_old.shape[1]] = wnext_old
+                layer, next_layer = layers[i], layers[i + 1]
+                W_new = layer.weight
+                Wnext_new = next_layer.weight
 
-            widen_linear(layers[i], layers[i + 1], add_k)
+                h_old, h_new = W_old.shape[0], W_new.shape[0]
+                add_units = h_new - h_old
+                if add_units < 0:
+                    raise ValueError(
+                        f"Layer '{name}': new width {h_new} < old width {h_old}. "
+                        "Function-preserving shrinking is not supported."
+                    )
+
+                # Copy overlap for L (rows) and its inputs (cols)
+                in_cols = min(W_new.shape[1], W_old.shape[1])
+                W_new[:min(h_old, h_new), :in_cols].copy_(
+                    W_old[:min(h_old, h_new), :in_cols])
+                if b_old is not None and layer.bias is not None:
+                    layer.bias[:min(h_old, h_new)].copy_(
+                        b_old[:min(h_old, h_new)])
+
+                # Copy overlap for Lnext across BOTH rows and columns
+                # handles changed out_features in hidden layers
+                rows = min(Wnext_new.shape[0], Wnext_old.shape[0])
+                cols = min(Wnext_new.shape[1], Wnext_old.shape[1], h_old)
+                Wnext_new[:rows, :cols].copy_(Wnext_old[:rows, :cols])
+                if bnext_old is not None and next_layer.bias is not None:
+                    next_layer.bias[:rows].copy_(bnext_old[:rows])
+
+                # Adjacency must hold for widening
+                assert Wnext_new.shape[1] == W_new.shape[0], \
+                    f"Adjacency mismatch: {next_name}.in_features={Wnext_new.shape[1]} vs {name}.out_features={W_new.shape[0]}"
+
+                # function-preserving widening by duplication/splitting
+                widen_linear(layer, next_layer, add_units)

--- a/src/core/neural_net.py
+++ b/src/core/neural_net.py
@@ -4,6 +4,10 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from typing import Optional
+
+from src.utils.net2net import widen_linear
+
 
 class NeuralNet(nn.Module):
     """Fully connected neural network used in PINNs.
@@ -16,6 +20,7 @@ class NeuralNet(nn.Module):
         activation: Activation function name (`tanh`, `relu`, ...).
         device: Device on which tensors should be allocated.
         dtype: Default tensor data type.
+        state_dict_path: Optional path to a checkpoint for initialization.
     """
 
     def __init__(
@@ -27,6 +32,7 @@ class NeuralNet(nn.Module):
         activation: str = "tanh",
         device: str = "cpu",
         dtype: torch.dtype = torch.float32,
+        state_dict_path: Optional[str] = None,
     ) -> None:
         super().__init__()
 
@@ -57,9 +63,49 @@ class NeuralNet(nn.Module):
         # Default loss function used by training strategies
         self.mse_loss = nn.MSELoss()
 
+        self.to(device=device, dtype=dtype)
+
+        if state_dict_path is not None:
+            self._initialize_from_checkpoint(state_dict_path)
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Compute network outputs for the given input coordinates."""
         x = self.activation(self.input_layer(x))
         for hidden_layer in self.hidden_layers:
             x = self.activation(hidden_layer(x))
         return self.output_layer(x)
+
+    # ------------------------------------------------------------------
+    def _initialize_from_checkpoint(self, path: str) -> None:
+        """Load weights from a checkpoint, widening layers if needed."""
+        checkpoint = torch.load(path, map_location=self.device)
+        state_dict = checkpoint.get("model_state", checkpoint)
+
+        # Load matching parameters
+        self.load_state_dict(state_dict, strict=False)
+
+        layers = [self.input_layer] + list(self.hidden_layers) + [self.output_layer]
+        names = ["input_layer"] + [f"hidden_layers.{i}" for i in range(len(self.hidden_layers))] + ["output_layer"]
+
+        for i in range(len(layers) - 1):
+            name, next_name = names[i], names[i + 1]
+            w_old = state_dict.get(f"{name}.weight")
+            if w_old is None:
+                continue
+            h_old = w_old.shape[0]
+            h_new = layers[i].weight.shape[0]
+            add_k = h_new - h_old
+            if add_k <= 0:
+                continue
+
+            b_old = state_dict.get(f"{name}.bias")
+            layers[i].weight.data[:h_old, :w_old.shape[1]] = w_old
+            if b_old is not None:
+                layers[i].bias.data[:h_old] = b_old
+
+            wnext_old = state_dict.get(f"{next_name}.weight")
+            if wnext_old is None:
+                continue
+            layers[i + 1].weight.data[:, :wnext_old.shape[1]] = wnext_old
+
+            widen_linear(layers[i], layers[i + 1], add_k)

--- a/src/training/strategies.py
+++ b/src/training/strategies.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 import math
 import time
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 
 import torch
@@ -45,7 +45,7 @@ class StandardStrategy(TrainingStrategy):
         epochs: int = 1000,
         loss_threshold: float = 1e-4,
         bc_weight: float = 10.0,
-        epoch_callback: Any | None = None,
+        epoch_callback: Callable | None = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Standard training loop"""
@@ -126,6 +126,10 @@ class StandardStrategy(TrainingStrategy):
                 break
 
         pbar.close()
+
+        # Final evaluation
+        if epoch_callback is not None:
+            epoch_callback(0, val)
 
         elapsed = time.time() - start_time
         model.eval()

--- a/src/training/strategies.py
+++ b/src/training/strategies.py
@@ -45,6 +45,7 @@ class StandardStrategy(TrainingStrategy):
         epochs: int = 1000,
         loss_threshold: float = 1e-4,
         bc_weight: float = 10.0,
+        epoch_callback: Any | None = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Standard training loop"""
@@ -88,6 +89,9 @@ class StandardStrategy(TrainingStrategy):
             # Record loss
             val = losses["total_loss"].item()
             loss_history.append(val)
+
+            if epoch_callback is not None:
+                epoch_callback(epoch, val)
 
             # EMA for stable display + stopping
             ema = val if ema is None else (

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -22,11 +22,16 @@ class Trainer:
         optimizer_config: Dict[str, Any],
         strategy: Union[str, TrainingStrategy] = "standard",
         experiment_config: Optional[ExperimentConfig] = None,
+        checkpoint_path: Optional[str] = None,
+        checkpoint_interval: int = 1,
     ) -> None:
         self.model = model
         self.problem = problem
         self.domain = domain
         self.experiment_config = experiment_config or ExperimentConfig()
+        self.checkpoint_path = checkpoint_path
+        self.checkpoint_interval = checkpoint_interval
+        self._best_loss = float("inf")
 
         self._create_optimizer(optimizer_config)
 
@@ -85,6 +90,15 @@ class Trainer:
             device=self.model.device,
         )
 
+        def epoch_callback(epoch: int, loss_val: float) -> None:
+            if self.checkpoint_path is None:
+                return
+            if epoch % self.checkpoint_interval != 0:
+                return
+            if loss_val < self._best_loss:
+                torch.save(self.model.state_dict(), self.checkpoint_path)
+                self._best_loss = loss_val
+
         # Execute training strategy
         return self.strategy.train(
             model=self.model,
@@ -96,5 +110,6 @@ class Trainer:
             epochs=epochs,
             loss_threshold=loss_threshold,
             bc_weight=bc_weight,
+            epoch_callback=epoch_callback,
             **kwargs,
         )

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -22,14 +22,14 @@ class Trainer:
         optimizer_config: Dict[str, Any],
         strategy: Union[str, TrainingStrategy] = "standard",
         experiment_config: Optional[ExperimentConfig] = None,
-        checkpoint_path: Optional[str] = None,
-        checkpoint_interval: int = 1,
+        save_path: Optional[str] = None,
+        checkpoint_interval: int = 100,
     ) -> None:
         self.model = model
         self.problem = problem
         self.domain = domain
         self.experiment_config = experiment_config or ExperimentConfig()
-        self.checkpoint_path = checkpoint_path
+        self.save_model_path = save_path
         self.checkpoint_interval = checkpoint_interval
         self._best_loss = float("inf")
 
@@ -91,12 +91,16 @@ class Trainer:
         )
 
         def epoch_callback(epoch: int, loss_val: float) -> None:
-            if self.checkpoint_path is None:
+            if self.save_model_path is None:
                 return
             if epoch % self.checkpoint_interval != 0:
                 return
             if loss_val < self._best_loss:
-                torch.save(self.model.state_dict(), self.checkpoint_path)
+                torch.save(self.model.state_dict(), self.save_model_path)
+                print(
+                    f"Loss improved to {loss_val:.2e}. "
+                    f"Model checkpoint saved to {self.save_model_path}"
+                )
                 self._best_loss = loss_val
 
         # Execute training strategy

--- a/src/utils/net2net.py
+++ b/src/utils/net2net.py
@@ -1,0 +1,49 @@
+"""Utilities for Net2Net transformations."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Optional
+import random as _random
+
+import torch
+
+
+def widen_linear(
+    L: torch.nn.Linear,
+    Lnext: torch.nn.Linear,
+    add_k: int,
+    rng: Optional[_random.Random] = None,
+) -> None:
+    """Function-preserving widening of two adjacent ``nn.Linear`` layers.
+
+    This operates on layers that already have the *target* width ``h_old + add_k``.
+    The first ``h_old`` neurons are assumed to contain weights copied from a
+    smaller pretrained model. The newly added ``add_k`` neurons are populated by
+    replicating existing neurons and splitting the outgoing weights of ``Lnext``.
+    """
+
+    rng = _random if rng is None else rng
+
+    W, b = L.weight.data, L.bias.data
+    Wn = Lnext.weight.data
+
+    h_new, in_dim = W.shape
+    h_old = h_new - add_k
+    out_dim, _ = Wn.shape
+
+    # choose source indices to replicate
+    src_idx = [rng.randrange(h_old) for _ in range(add_k)]
+
+    # counts per source for splitting outgoing weights
+    cnt = Counter(src_idx)
+    for j, c in cnt.items():
+        Wn[:, j] = Wn[:, j] / (c + 1)
+
+    # add replicas in L and split columns in Lnext
+    col_ptr = h_old
+    for j in src_idx:
+        W[col_ptr] = W[j]
+        b[col_ptr] = b[j]
+        Wn[:, col_ptr] = Wn[:, j]
+        col_ptr += 1

--- a/src/utils/net2net.py
+++ b/src/utils/net2net.py
@@ -1,7 +1,5 @@
 """Utilities for Net2Net transformations."""
 
-from __future__ import annotations
-
 from collections import Counter
 from typing import Optional
 import random as _random
@@ -10,40 +8,44 @@ import torch
 
 
 def widen_linear(
-    L: torch.nn.Linear,
-    Lnext: torch.nn.Linear,
-    add_k: int,
+    layer: torch.nn.Linear,
+    next_layer: torch.nn.Linear,
+    add_units: int,
     rng: Optional[_random.Random] = None,
 ) -> None:
-    """Function-preserving widening of two adjacent ``nn.Linear`` layers.
-
-    This operates on layers that already have the *target* width ``h_old + add_k``.
-    The first ``h_old`` neurons are assumed to contain weights copied from a
-    smaller pretrained model. The newly added ``add_k`` neurons are populated by
-    replicating existing neurons and splitting the outgoing weights of ``Lnext``.
     """
+    Function-preserving *widening* for two adjacent Linear layers.
+
+    Math: duplicate neurons and split their outgoing weights.
+    If neuron j has activation h_j and outgoing column v_j, replicating it r times
+    and setting each outgoing column to v_j/(r+1) keeps
+        sum_{copies} v_j/(r+1) * h_j  = v_j * h_j,
+    so the network function is unchanged at init.
+    """
+    if add_units <= 0:
+        return  # caller guarantees no shrink; equal width needs no action
 
     rng = _random if rng is None else rng
+    with torch.no_grad():
+        W_in = layer.weight        # shape: (h_new, in_features)
+        b_in = layer.bias          # shape: (h_new,)
+        W_out = next_layer.weight   # shape: (out_features, h_new)
 
-    W, b = L.weight.data, L.bias.data
-    Wn = Lnext.weight.data
+        h_new = W_in.shape[0]
+        h_old = h_new - add_units
 
-    h_new, in_dim = W.shape
-    h_old = h_new - add_k
-    out_dim, _ = Wn.shape
+        # choose existing neurons to replicate
+        src_idx = [rng.randrange(h_old) for _ in range(add_units)]
 
-    # choose source indices to replicate
-    src_idx = [rng.randrange(h_old) for _ in range(add_k)]
+        # split outgoing columns once per source
+        replication_count = Counter(src_idx)
+        for j, c in replication_count.items():
+            W_out[:, j].div_(c + 1)
 
-    # counts per source for splitting outgoing weights
-    cnt = Counter(src_idx)
-    for j, c in cnt.items():
-        Wn[:, j] = Wn[:, j] / (c + 1)
-
-    # add replicas in L and split columns in Lnext
-    col_ptr = h_old
-    for j in src_idx:
-        W[col_ptr] = W[j]
-        b[col_ptr] = b[j]
-        Wn[:, col_ptr] = Wn[:, j]
-        col_ptr += 1
+        # write replicas into rows [h_old, ..., h_new-1]
+        write_row = h_old
+        for j in src_idx:
+            W_in[write_row].copy_(W_in[j])
+            b_in[write_row].copy_(b_in[j])
+            W_out[:, write_row].copy_(W_out[:, j])
+            write_row += 1


### PR DESCRIPTION
## Summary
- Allow Trainer to periodically checkpoint the best model during training
- Let NeuralNet load smaller checkpoints and widen layers with Net2Net
- Implement widen_linear utility for function-preserving layer expansion

## Testing
- `python -m py_compile src/utils/net2net.py src/core/neural_net.py src/training/trainer.py src/training/strategies.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc55e0bbd483248cd8994fbfa3f192